### PR TITLE
Removed unwrap that causes panic 

### DIFF
--- a/src/todo_app.rs
+++ b/src/todo_app.rs
@@ -307,10 +307,12 @@ impl App {
 
     #[inline]
     pub fn toggle_current_done(&mut self) {
-        self.todo_mut().unwrap().toggle_done();
-        self.reorder_current();
-        while self.is_undone_empty() && self.traverse_up() {
-            self.toggle_current_done()
+        if let Some(todo) = self.todo_mut() {
+            todo.toggle_done();
+            self.reorder_current();
+            while self.is_undone_empty() && self.traverse_up() {
+                self.toggle_current_done()
+            }
         }
     }
 


### PR DESCRIPTION
`Unwrap` caused a panic when the undone items list was empty, and you pressed the spacebar again.
